### PR TITLE
Add newline at end of __init__ module

### DIFF
--- a/src/ollama_ocr/__init__.py
+++ b/src/ollama_ocr/__init__.py
@@ -1,4 +1,5 @@
 """OCR powered by Ollama Model."""
+
 from .ocr_processor import OCRProcessor
 
 __version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- ensure `src/ollama_ocr/__init__.py` ends with a newline and format module

## Testing
- `black src/ollama_ocr/__init__.py`
- `python -m py_compile src/ollama_ocr/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68adca6f76d4832a9fac5359b60c3c06